### PR TITLE
docker jdk11

### DIFF
--- a/jobson-docker-jdk11/Dockerfile
+++ b/jobson-docker-jdk11/Dockerfile
@@ -1,0 +1,40 @@
+FROM azul/zulu-openjdk-alpine:11
+
+# Install 3rd-party dependencies
+RUN apk update && \
+    apk add nginx supervisor && \
+    rm -rf /etc/nginx/sites-enabled/default
+
+# Install jobson debian package
+COPY target/jobson.tar.gz /tmp
+RUN mkdir /tmp/jobson && \
+    cd /tmp/jobson && \
+    tar -xvf /tmp/jobson.tar.gz --strip-components=1 && \
+    mkdir -p /usr/share/jobson && \
+    mv /tmp/jobson/share/java /usr/share/jobson/ && \
+    mv /tmp/jobson/share/jobson/ui /usr/share/jobson/ && \
+    sed -i -E 's#".+/share#"/usr/share/jobson#' /tmp/jobson/bin/jobson && \
+    sed -i -E 's#bash#sh#' /tmp/jobson/bin/jobson && \
+    mv /tmp/jobson/bin/jobson /usr/bin/ && \
+    rm -rf /tmp/jobson.tar.gz /tmp/jobson && \
+    mkdir -p /run/nginx
+
+# Configure nginx
+COPY default.conf /etc/nginx/conf.d/default.conf
+
+# Configure supervisord
+COPY supervisord.conf /etc/supervisord.conf
+
+# Configure OS to have a 'jobson' account
+RUN addgroup -S jobson && \
+    adduser -S -G jobson jobson && \
+    mkdir -p /home/jobson && \
+    chown jobson:jobson /home/jobson
+
+# Configure 'jobson' account with a jobson workspace
+USER jobson
+RUN  cd /home/jobson && jobson new --demo  # so a blank img boot shows *something*
+USER root
+
+EXPOSE 80
+CMD ["supervisord", "--configuration", "/etc/supervisord.conf", "--nodaemon"]

--- a/jobson-docker-jdk11/Dockerfile
+++ b/jobson-docker-jdk11/Dockerfile
@@ -2,7 +2,7 @@ FROM azul/zulu-openjdk-alpine:11
 
 # Install 3rd-party dependencies
 RUN apk update && \
-    apk add nginx supervisor && \
+    apk add bash nginx supervisor && \
     rm -rf /etc/nginx/sites-enabled/default
 
 # Install jobson debian package
@@ -20,7 +20,7 @@ RUN mkdir /tmp/jobson && \
     mkdir -p /run/nginx
 
 # Configure nginx
-COPY default.conf /etc/nginx/conf.d/default.conf
+COPY default.conf /etc/nginx/http.d/default.conf
 
 # Configure supervisord
 COPY supervisord.conf /etc/supervisord.conf

--- a/jobson-docker-jdk11/README.md
+++ b/jobson-docker-jdk11/README.md
@@ -1,0 +1,26 @@
+# jobson-docker
+
+Docker packaging for Jobson.
+
+Builds a standard docker image that pre-integrates `jobson` with `jobson-ui` (with
+`nginx`).
+
+
+# Filesystem
+
+- A standard `jobson` workspace is created for the image at `/home/jobson`. Users
+  should copy/remount this with their own configuration
+- `nginx` configuration is in the standard location (e.g. `/etc/nginx`) if users 
+  want to reconfigure the webserver (e.g. with HTTPS)
+  
+# Execution
+
+- Top-level uses `supervisord` to supervise `jobson` and `nginx`
+- All execution performed by the `jobson` user. Users of this image should ensure
+  that `jobson` can execute the underling application 
+
+# Ports
+
+- Exposes `nginx` on port 80
+- Forwards any requests beginning with `/api` to a `jobson` server listening on
+  port 8080 (not exposed)

--- a/jobson-docker-jdk11/default.conf
+++ b/jobson-docker-jdk11/default.conf
@@ -1,0 +1,35 @@
+server {
+    access_log /dev/stdout;
+    error_log /dev/stdout info;
+
+    listen       80;
+    server_name  localhost;
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/jobson/ui/html;
+        index  index.html index.htm;
+    }
+
+    location /api/ {
+
+    	# Any requests beginning with /api should be forwarded
+	# to Jobson
+	proxy_pass http://localhost:8080;
+
+	# The Jobson server itself doesn't take an /api prefix
+	# (it's just used for routing), so drop it.
+	rewrite ^/api/(.*) /$1 break;
+
+	# Websocket support
+	proxy_http_version 1.1;
+	proxy_set_header Upgrade $http_upgrade;
+	proxy_set_header Connection "upgrade";
+	proxy_read_timeout 86400;
+    }
+}
+
+
+

--- a/jobson-docker-jdk11/default.conf
+++ b/jobson-docker-jdk11/default.conf
@@ -2,6 +2,8 @@ server {
     access_log /dev/stdout;
     error_log /dev/stdout info;
 
+    client_max_body_size 80M;
+
     listen       80;
     server_name  localhost;
 
@@ -15,19 +17,19 @@ server {
 
     location /api/ {
 
-    	# Any requests beginning with /api should be forwarded
-	# to Jobson
-	proxy_pass http://localhost:8080;
+        # Any requests beginning with /api should be forwarded
+        # to Jobson
+        proxy_pass http://localhost:8080;
 
-	# The Jobson server itself doesn't take an /api prefix
-	# (it's just used for routing), so drop it.
-	rewrite ^/api/(.*) /$1 break;
+        # The Jobson server itself doesn't take an /api prefix
+        # (it's just used for routing), so drop it.
+        rewrite ^/api/(.*) /$1 break;
 
-	# Websocket support
-	proxy_http_version 1.1;
-	proxy_set_header Upgrade $http_upgrade;
-	proxy_set_header Connection "upgrade";
-	proxy_read_timeout 86400;
+        # Websocket support
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 86400;
     }
 }
 

--- a/jobson-docker-jdk11/pom.xml
+++ b/jobson-docker-jdk11/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.jobson</groupId>
+        <artifactId>jobson-project</artifactId>
+        <version>1.0.11</version>
+    </parent>
+
+    <artifactId>jobson-docker-jdk11</artifactId>
+    <packaging>pom</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.jobson</groupId>
+            <artifactId>jobson-nix</artifactId>
+            <version>1.0.11</version>
+            <type>tar.gz</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <!-- Unpack the jobson-nix distro: it contains jobson, UI, etc. -->
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.github.jobson</groupId>
+                                    <artifactId>jobson-nix</artifactId>
+                                    <type>tar.gz</type>
+                                    <outputDirectory>
+                                        ${project.build.directory}
+                                    </outputDirectory>
+                                    <destFileName>jobson.tar.gz</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>build-docker-image</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <exec executable="docker" failonerror="true">
+                                    <arg value="build"/>
+                                    <arg value="-t"/>
+                                    <arg value="${docker.user}/${docker.repo}-jdk11:${project.version}"/>
+                                    <arg value="-t"/>
+                                    <arg value="${docker.user}/${docker.repo}-jdk11:latest"/>
+                                    <arg value="."/>
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jobson-docker-jdk11/pom.xml
+++ b/jobson-docker-jdk11/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.jobson</groupId>
         <artifactId>jobson-project</artifactId>
-        <version>1.0.11</version>
+        <version>1.0.12</version>
     </parent>
 
     <artifactId>jobson-docker-jdk11</artifactId>
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>com.github.jobson</groupId>
             <artifactId>jobson-nix</artifactId>
-            <version>1.0.11</version>
+            <version>1.0.12</version>
             <type>tar.gz</type>
         </dependency>
     </dependencies>

--- a/jobson-docker-jdk11/supervisord.conf
+++ b/jobson-docker-jdk11/supervisord.conf
@@ -1,0 +1,30 @@
+[supervisord]
+logfile=/tmp/supervisord.log 
+logfile_maxbytes=50MB 
+logfile_backups=10 
+loglevel=info 
+pidfile=/tmp/supervisord.pid
+nodaemon=false
+minfds=1024
+minprocs=200
+user=root
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[program:nginx]
+command=nginx -g 'daemon off;'
+user=root
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:jobson]
+command=jobson serve config.yml
+directory=/home/jobson
+user=jobson
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/pom.xml
+++ b/pom.xml
@@ -142,8 +142,10 @@
         <module>jobson-docs</module>
 
         <!-- Packaging -->
-        <module>jobson-deb</module>
         <module>jobson-nix</module>
+        <module>jobson-deb</module>
         <module>jobson-docker</module>
+        <module>jobson-docker-jdk11</module>
     </modules>
+
 </project>


### PR DESCRIPTION
Hi, I would like to contribute to jobson.

I wanted to use jobson for running java 11 application and unfortunately the existing image is using java 8. And I also  wanted the smaller docker image, as for me, I do not need features from ubuntu.

So, after playing around a bit, I came up with an azul/zulu-open-jdk-alpine:11 based docker running jobson, and added to jobson project as jobson-docker-jdk11 sub-module.

Hopefully this PR can help others with similar requirements.